### PR TITLE
Update mtzip to 1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ name = "mtzip"
 crate-type =["cdylib","staticlib"]
 
 [dependencies]
-mtzip = "0.5.0"
+mtzip = "1.0.0"

--- a/include/mtzip.h
+++ b/include/mtzip.h
@@ -40,7 +40,11 @@ extern int mtzip_zip_archive_add_directory(mtzip_zip_archive_t* zip_archive, con
 
 extern int mtzip_zip_archive_compress(mtzip_zip_archive_t* zip_archive, size_t threads);
 
+extern int mtzip_zip_archive_compress_autothread(mtzip_zip_archive_t* zip_archive);
+
 extern int mtzip_zip_archive_write(mtzip_zip_archive_t* zip_archive, const char* file_name, size_t threads);
+
+extern int mtzip_zip_archive_write_autothread(mtzip_zip_archive_t* zip_archive, const char* file_name);
 
 extern void mtzip_zip_archive_clean(mtzip_zip_archive_t* zip_archive);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,7 @@ unsafe extern "C" fn mtzip_zip_archive_compress(
     threads: usize,
 ) -> c_int {
     let zipper = &*((*zip_archive).zip_archive as *mut ZipArchive);
-    zipper.compress(threads);
+    zipper.compress_with_threads(threads);
     0
 }
 
@@ -116,9 +116,9 @@ unsafe extern "C" fn mtzip_zip_archive_write(
         Err(_) => return -1,
     };
     if threads == 0 {
-        zipper.write(&mut file, None);
+        zipper.write_with_threads(&mut file, 1);
     } else {
-        zipper.write(&mut file, Some(threads));
+        zipper.write_with_threads(&mut file, threads);
     }
     0
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,16 @@
 /*
 * Copyright (c) 2022 XXIV
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -19,38 +19,40 @@
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 * SOFTWARE.
 */
-use std::os::raw::c_void;
+use mtzip::ZipArchive;
+use std::ffi::CStr;
+use std::fs::File;
 use std::os::raw::c_char;
 use std::os::raw::c_int;
-use std::ffi::CStr;
+use std::os::raw::c_void;
 use std::slice;
-use std::fs::File;
-use mtzip::ZipArchive;
 
 #[repr(C)]
 struct mtzip_zip_archive_t {
-    zip_archive: *mut c_void
+    zip_archive: *mut c_void,
 }
 
 #[no_mangle]
 unsafe extern "C" fn mtzip_zip_archive_default() -> mtzip_zip_archive_t {
     let zipper = ZipArchive::default();
     return mtzip_zip_archive_t {
-	zip_archive: Box::into_raw(Box::new(zipper)) as *mut c_void
+        zip_archive: Box::into_raw(Box::new(zipper)) as *mut c_void,
     };
 }
 
 #[no_mangle]
-unsafe extern "C" fn mtzip_zip_archive_add_file(zip_archive: *mut mtzip_zip_archive_t,
-						fs_path: *const c_char,
-						archive_name: *const c_char) -> c_int {
+unsafe extern "C" fn mtzip_zip_archive_add_file(
+    zip_archive: *mut mtzip_zip_archive_t,
+    fs_path: *const c_char,
+    archive_name: *const c_char,
+) -> c_int {
     let fs_path_rs = match CStr::from_ptr(fs_path).to_str() {
-	Ok(v) => v,
-	Err(_) => return -1
+        Ok(v) => v,
+        Err(_) => return -1,
     };
     let archive_name_rs = match CStr::from_ptr(archive_name).to_str() {
-	Ok(v) => v,
-	Err(_) => return -1
+        Ok(v) => v,
+        Err(_) => return -1,
     };
     let zipper = &*((*zip_archive).zip_archive as *mut ZipArchive);
     zipper.add_file(fs_path_rs, archive_name_rs);
@@ -58,14 +60,16 @@ unsafe extern "C" fn mtzip_zip_archive_add_file(zip_archive: *mut mtzip_zip_arch
 }
 
 #[no_mangle]
-unsafe extern "C" fn mtzip_zip_archive_add_file_from_bytes(zip_archive: *mut mtzip_zip_archive_t,
-							   data: *const u8,
-							   data_len: usize,
-							   archive_name: *const c_char) -> c_int {
+unsafe extern "C" fn mtzip_zip_archive_add_file_from_bytes(
+    zip_archive: *mut mtzip_zip_archive_t,
+    data: *const u8,
+    data_len: usize,
+    archive_name: *const c_char,
+) -> c_int {
     let data_rs = slice::from_raw_parts(data, data_len);
     let archive_name_rs = match CStr::from_ptr(archive_name).to_str() {
-	Ok(v) => v,
-	Err(_) => return -1
+        Ok(v) => v,
+        Err(_) => return -1,
     };
     let zipper = &*((*zip_archive).zip_archive as *mut ZipArchive);
     zipper.add_file_from_slice(data_rs, archive_name_rs);
@@ -73,11 +77,13 @@ unsafe extern "C" fn mtzip_zip_archive_add_file_from_bytes(zip_archive: *mut mtz
 }
 
 #[no_mangle]
-unsafe extern "C" fn mtzip_zip_archive_add_directory(zip_archive: *mut mtzip_zip_archive_t,
-						     archive_name: *const c_char) -> c_int {
+unsafe extern "C" fn mtzip_zip_archive_add_directory(
+    zip_archive: *mut mtzip_zip_archive_t,
+    archive_name: *const c_char,
+) -> c_int {
     let archive_name_rs = match CStr::from_ptr(archive_name).to_str() {
-	Ok(v) => v,
-	Err(_) => return -1
+        Ok(v) => v,
+        Err(_) => return -1,
     };
     let zipper = &*((*zip_archive).zip_archive as *mut ZipArchive);
     zipper.add_directory(archive_name_rs);
@@ -85,30 +91,34 @@ unsafe extern "C" fn mtzip_zip_archive_add_directory(zip_archive: *mut mtzip_zip
 }
 
 #[no_mangle]
-unsafe extern "C" fn mtzip_zip_archive_compress(zip_archive: *mut mtzip_zip_archive_t,
-						     threads: usize) -> c_int {
+unsafe extern "C" fn mtzip_zip_archive_compress(
+    zip_archive: *mut mtzip_zip_archive_t,
+    threads: usize,
+) -> c_int {
     let zipper = &*((*zip_archive).zip_archive as *mut ZipArchive);
     zipper.compress(threads);
     0
 }
 
 #[no_mangle]
-unsafe extern "C" fn mtzip_zip_archive_write(zip_archive: *mut mtzip_zip_archive_t,
-					     file_name: *const c_char,
-					     threads: usize) -> c_int {
+unsafe extern "C" fn mtzip_zip_archive_write(
+    zip_archive: *mut mtzip_zip_archive_t,
+    file_name: *const c_char,
+    threads: usize,
+) -> c_int {
     let file_name_rs = match CStr::from_ptr(file_name).to_str() {
-	Ok(v) => v,
-	Err(_) => return -1
+        Ok(v) => v,
+        Err(_) => return -1,
     };
     let zipper = &*((*zip_archive).zip_archive as *mut ZipArchive);
     let mut file = match File::create(file_name_rs) {
-	Ok(v) => v,
-	Err(_) => return -1
+        Ok(v) => v,
+        Err(_) => return -1,
     };
     if threads == 0 {
-	zipper.write(&mut file, None);
+        zipper.write(&mut file, None);
     } else {
-	zipper.write(&mut file , Some(threads));
+        zipper.write(&mut file, Some(threads));
     }
     0
 }
@@ -116,6 +126,6 @@ unsafe extern "C" fn mtzip_zip_archive_write(zip_archive: *mut mtzip_zip_archive
 #[no_mangle]
 unsafe extern "C" fn mtzip_zip_archive_clean(zip_archive: *mut mtzip_zip_archive_t) {
     if !zip_archive.is_null() {
-	let _ = Box::from_raw((*zip_archive).zip_archive as *mut ZipArchive);
+        let _ = Box::from_raw((*zip_archive).zip_archive as *mut ZipArchive);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,15 @@ unsafe extern "C" fn mtzip_zip_archive_compress(
 }
 
 #[no_mangle]
+unsafe extern "C" fn mtzip_zip_archive_compress_autothread(
+    zip_archive: *mut mtzip_zip_archive_t,
+) -> c_int {
+    let zipper = &*((*zip_archive).zip_archive as *mut ZipArchive);
+    zipper.compress();
+    0
+}
+
+#[no_mangle]
 unsafe extern "C" fn mtzip_zip_archive_write(
     zip_archive: *mut mtzip_zip_archive_t,
     file_name: *const c_char,
@@ -120,6 +129,24 @@ unsafe extern "C" fn mtzip_zip_archive_write(
     } else {
         zipper.write_with_threads(&mut file, threads);
     }
+    0
+}
+
+#[no_mangle]
+unsafe extern "C" fn mtzip_zip_archive_write_autothread(
+    zip_archive: *mut mtzip_zip_archive_t,
+    file_name: *const c_char,
+) -> c_int {
+    let file_name_rs = match CStr::from_ptr(file_name).to_str() {
+        Ok(v) => v,
+        Err(_) => return -1,
+    };
+    let zipper = &*((*zip_archive).zip_archive as *mut ZipArchive);
+    let mut file = match File::create(file_name_rs) {
+        Ok(v) => v,
+        Err(_) => return -1,
+    };
+    zipper.write(&mut file);
     0
 }
 


### PR DESCRIPTION
Updated mtzip dependency, added support for new thread count auto-detection, formatted rust code according to the standard.