### PR TITLE
Readme edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,13 @@ int mtzip_zip_archive_add_file_from_bytes(mtzip_zip_archive_t* zip_archive, uint
 
 int mtzip_zip_archive_add_directory(mtzip_zip_archive_t* zip_archive, const char* archive_name);
 
-int mtzip_zip_archive_compress(mtzip_zip_archive_t* zip_archive, size_t threads);
+int mtzip_zip_archive_compress(mtzip_zip_archive_t* zip_archive);
 
-int mtzip_zip_archive_write(mtzip_zip_archive_t* zip_archive, const char* file_name, size_t threads);
+int mtzip_zip_archive_compress_autothread(mtzip_zip_archive_t* zip_archive, size_t threads);
+
+int mtzip_zip_archive_write(mtzip_zip_archive_t* zip_archive, const char* file_name);
+
+int mtzip_zip_archive_write_autothread(mtzip_zip_archive_t* zip_archive, const char* file_name, size_t threads);
 
 void mtzip_zip_archive_clean(mtzip_zip_archive_t* zip_archive);
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ cd libmtzip
 ```
 #### 3. Build the project
 ```
-cargo build
+cargo build --release
 ```
 
 ### API

--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ int mtzip_zip_archive_add_file_from_bytes(mtzip_zip_archive_t* zip_archive, uint
 
 int mtzip_zip_archive_add_directory(mtzip_zip_archive_t* zip_archive, const char* archive_name);
 
-int mtzip_zip_archive_compress(mtzip_zip_archive_t* zip_archive);
+int mtzip_zip_archive_compress(mtzip_zip_archive_t* zip_archive, size_t threads);
 
-int mtzip_zip_archive_compress_autothread(mtzip_zip_archive_t* zip_archive, size_t threads);
+int mtzip_zip_archive_compress_autothread(mtzip_zip_archive_t* zip_archive);
 
-int mtzip_zip_archive_write(mtzip_zip_archive_t* zip_archive, const char* file_name);
+int mtzip_zip_archive_write(mtzip_zip_archive_t* zip_archive, const char* file_name, size_t threads);
 
-int mtzip_zip_archive_write_autothread(mtzip_zip_archive_t* zip_archive, const char* file_name, size_t threads);
+int mtzip_zip_archive_write_autothread(mtzip_zip_archive_t* zip_archive, const char* file_name);
 
 void mtzip_zip_archive_clean(mtzip_zip_archive_t* zip_archive);
 ```


### PR DESCRIPTION
Added `--release` flag to build instructions, which makes cargo build non-debug version with improved performance.

Added new API docs to readme.